### PR TITLE
Make coveralls a dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.5"
 requests = "^2.0.0'"
-coveralls = "^2.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0.1"
 pytest-cov = "^2.10.1"
 pytest-vcr = "^1.0.2"
 flake8 = "^3.8.3"
+coveralls = "^2.1.2"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Coveralls should be a dev dependency, so that when using Aftership in production it doesn't bring coveralls and it's dependencies in too.