### PR TITLE
authentication: add AES support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,31 @@ The functions of the SDK will return `data` field value if the API endpoints
 return response with HTTP status :code:`2XX`, otherwise will throw an
 exception.
 
+Authentication
+===========
+
+You can authenticate your request with AES algorithm
+
+.. code-block:: python
+
+    import aftership
+    aftership.api_key = 'YOUR_API_KEY_FROM_AFTERSHIP'
+    aftership.api_aes_secret_key = 'YOUR_API_SECRET_KEY_FROM_AFTERSHIP'
+    couriers = aftership.courier.list_couriers()
+
+You can also set API secret key via setting :code:`AFTERSHIP_API_AES_SECRET_KEY` environment varaible.
+
+.. code-block:: bash
+
+    export AFTERSHIP_API_KEY=THIS_IS_MY_API_KEY
+    export AFTERSHIP_API_AES_SECRET_KEY=THIS_IS_MY_SECRET_KEY
+
+.. code-block:: python
+
+    import aftership
+    tracking = aftership.get_tracking(tracking_id='your_tracking_id')
+
+
 Exceptions
 ==========
 

--- a/aftership/__init__.py
+++ b/aftership/__init__.py
@@ -4,3 +4,4 @@ from . import courier, exception, tracking, notification, estimated_delivery_dat
 __version__ = '1.3.0'
 
 api_key = None
+api_aes_secret_key = None

--- a/aftership/const.py
+++ b/aftership/const.py
@@ -1,4 +1,4 @@
-API_KEY_FILED_NAME = 'aftership-api-key'
+API_KEY_FILED_NAME = 'as-api-key'
 
 API_VERSION = "v4"
-API_ENDPOINT = "https://api.aftership.com/v4/"
+API_ENDPOINT = f"https://api.aftership.com/{API_VERSION}/"

--- a/aftership/request.py
+++ b/aftership/request.py
@@ -1,13 +1,50 @@
 from urllib.parse import urljoin
+import hashlib
+from email.utils import formatdate
+import hmac
+import base64
 
 import requests
 
-from .const import API_KEY_FILED_NAME, API_ENDPOINT
-from .util import get_api_key
+from .const import API_KEY_FILED_NAME, API_ENDPOINT, API_VERSION
+from .util import get_api_key, get_api_secret_key
 
 
 def build_request_url(path):
     return urljoin(API_ENDPOINT, path)
+
+
+def generate_date_rfc1123():
+    return formatdate(timeval=None, localtime=False, usegmt=True)
+
+
+def sign_request(method, path, headers, content):
+    sign_string = generate_sign_string(method, path, headers, content)
+    signature = hmac.new(get_api_secret_key().encode(), msg=sign_string.encode(), digestmod=hashlib.sha256)
+    b64_signature = base64.b64encode(signature.digest()).decode()
+
+    headers['as-signature-hmac-sha256'] = b64_signature
+
+
+def generate_sign_string(method, path, headers, content):
+    content_md5 = hashlib.md5(content).upper() if content else ''
+    content_type = 'application/json' if content else ''
+    date = generate_date_rfc1123()
+    as_headers = {
+        k.lower().strip(): v.strip()
+        for k, v in sorted(headers.items())
+        if k.lower().startswith('as-')
+    }
+    canonicalized_headers = ''
+    if as_headers:
+        canonicalized_headers = ''.join([f'{k}:{v}' for k, v in as_headers.items()])
+    canonicalized_resource = f'/{API_VERSION}/{path}'
+
+    headers['date'] = date
+    headers['content-type'] = content_type
+
+    return '\n'.join((method, content_md5, content_type, date,
+                      canonicalized_headers, canonicalized_resource))
 
 
 def make_request(method, path, **kwargs):
@@ -16,5 +53,9 @@ def make_request(method, path, **kwargs):
     headers = kwargs.pop('headers', dict())
     if headers.get(API_KEY_FILED_NAME) is None:
         headers[API_KEY_FILED_NAME] = get_api_key()
+
+    if get_api_secret_key():
+        sign_request(method, path, headers, kwargs.get('json'))
+
     kwargs['headers'] = headers
     return requests.request(method, url, **kwargs)

--- a/aftership/util.py
+++ b/aftership/util.py
@@ -23,3 +23,10 @@ def get_api_key():
     if aftership.api_key is not None:
         return aftership.api_key
     return os.getenv('AFTERSHIP_API_KEY')
+
+
+def get_api_secret_key():
+    """Get AfterShip API secret key"""
+    if aftership.api_aes_secret_key is not None:
+        return aftership.api_aes_secret_key
+    return os.getenv('AFTERSHIP_API_AES_SECRET_KEY')


### PR DESCRIPTION
Currently, the Python SDK only support basic API key authentication. This patch adds the support for AES authentication which is important if you want to properly secure your requests.

Documentation is updated too.